### PR TITLE
Stop processes gracefully on shutdown

### DIFF
--- a/launch_overpass.sh
+++ b/launch_overpass.sh
@@ -2,6 +2,9 @@
 
 source conf.sh
 
+# Kill all background processes on exit
+trap "exit" INT TERM
+trap "kill 0" EXIT
 
 #If database doesn't exist, fetch the .osm and init the overpass db
 echo "Raw installation, will init DB from .osm planet"

--- a/run.sh
+++ b/run.sh
@@ -4,12 +4,13 @@ source conf.sh
 
 
 exitGracefully() {
-	kill $(ps aux | grep fetch_osc_and_apply | awk '{print $2}')
+	service apache2 stop
+	pkill fetch_osc_and_apply
 	sleep 8
-	kill $(ps aux | grep osm-base | awk '{print $2}')
+	pkill osm-base
 }
 
-trap exitGracefully SIGTERM
+trap exitGracefully EXIT
 
 sleep 20
 


### PR DESCRIPTION
Apache wouldn't come up after a `docker-compose restart`, because the
PID file is still there. Give Apache and all other processes a chance to
stop gracefully when the container is shut down.